### PR TITLE
Add Layout and Providers for app foundation with fonts and global pro…

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,30 +1,31 @@
 import { Geist, Geist_Mono } from "next/font/google"
-
 import "@workspace/ui/globals.css"
-import { Providers } from "@/components/providers"
+import {Providers} from "@/app/providers";
+
 
 const fontSans = Geist({
-  subsets: ["latin"],
-  variable: "--font-sans",
+    subsets: ["latin"],
+    variable: "--font-sans",
 })
 
 const fontMono = Geist_Mono({
-  subsets: ["latin"],
-  variable: "--font-mono",
+    subsets: ["latin"],
+    variable: "--font-mono",
 })
 
 export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode
+                                       children,
+                                   }: Readonly<{
+    children: React.ReactNode
 }>) {
-  return (
-    <html lang="en" suppressHydrationWarning>
-      <body
-        className={`${fontSans.variable} ${fontMono.variable} font-sans antialiased `}
-      >
+    return (
+        <html lang="en" suppressHydrationWarning>
+        <body
+
+            className={`${fontSans.variable} ${fontMono.variable} font-sans antialiased `}
+        >
         <Providers>{children}</Providers>
-      </body>
-    </html>
-  )
+        </body>
+        </html>
+    )
 }

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ThemeProvider } from "next-themes";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+import { Toaster } from "react-hot-toast";
+
+export function Providers({ children }: { children: ReactNode }) {
+    const [queryClient] = useState(() => new QueryClient());
+
+    return (
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+            <QueryClientProvider client={queryClient}>
+                {children}
+                <Toaster position="top-right" toastOptions={{ duration: 2000 }} />
+            </QueryClientProvider>
+        </ThemeProvider>
+    );
+}


### PR DESCRIPTION
…viders.

 Thiết lập layout gốc của app Next.js với font Geist/Geist Mono cho typography. Providers.tsx tích hợp ThemeProvider (next-themes), QueryClientProvider (TanStack Query) và Toaster (react-hot-toast) để quản lý theme, data fetching và notifications toàn cục. Đảm bảo app responsive, hỗ trợ dark/light mode và suppress hydration warnings.