### PR TITLE
Add Avatar component with initials and DiceBear avatar.

### DIFF
--- a/apps/web/components/Avatar.tsx
+++ b/apps/web/components/Avatar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import type { Assignee } from "@/types";
+import {cn} from "@workspace/ui/lib/utils";
+
+type Props = {
+    user: Assignee;
+    className?: string;
+};
+
+export default function Avatar({ user, className }: Props) {
+    const initials = user.name
+        .split(" ")
+        .map((n) => n[0])
+        .join("")
+        .slice(0, 2)
+        .toUpperCase();
+
+    return (
+        <AvatarPrimitive.Root
+            className={cn(
+                "inline-flex h-8 w-8 sm:h-10 sm:w-10 items-center justify-center rounded-full bg-primary/10 text-primary font-medium",
+                className
+            )}
+        >
+            <AvatarPrimitive.Image
+                src={`https://api.dicebear.com/7.x/initials/svg?seed=${user.name}`}
+                alt={`${user.name}'s avatar`}
+                className="h-full w-full rounded-full object-cover"
+            />
+            <AvatarPrimitive.Fallback className="text-sm sm:text-base">
+                {initials}
+            </AvatarPrimitive.Fallback>
+        </AvatarPrimitive.Root>
+    );
+}


### PR DESCRIPTION
 Component Avatar (Avatar.tsx) sử dụng @radix-ui/react-avatar để hiển thị avatar người dùng với initials (2 chữ cái đầu tên). Fallback SVG từ DiceBear API nếu không có ảnh, responsive size (8-10px). Tích hợp type Assignee từ types.